### PR TITLE
fix: google calender api call limited error

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,7 @@ Error: API call to calendar.events.insert failed with error: Calendar usage limi
 
 **Causes and Solutions:**  
 - ❌ Events outside the sync range were repeatedly created, exceeding Google Calendar API quotas
-  - ✅ Run `cleanupDuplicateEvents(true)` as a dry run to check the scale of duplicates
-  - ✅ Run `cleanupDuplicateEvents(false)` to delete duplicate events
+  - ✅ Run `cleanupDuplicateEvents()` to delete duplicate events (run repeatedly until complete)
   - ✅ Update to the latest version to apply the date range filter fix
 
 ### 🔍 Debugging Methods
@@ -321,11 +320,11 @@ function checkConfiguration() {
 
 #### Cleaning Up Duplicate Events
 ```javascript
-// Check for duplicate events (dry run)
-cleanupDuplicateEvents(true);
+// Detect and delete duplicate events (resumable, run repeatedly until complete)
+cleanupDuplicateEvents();
 
-// Delete duplicate events (execute)
-cleanupDuplicateEvents(false);
+// Reset progress and start over
+resetCleanupProgress();
 ```
 
 ### ⚠️ Important Notes

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This function performs the following:
 #### Sync Target Conditions
 - ✅ "Schedule" tag is included in `Tags`
 - ✅ `Action Day` is set
+- ✅ `Action Day` is within sync range (30 days ago to 90 days ahead)
 - ❌ Items not meeting the above criteria are excluded from sync
 
 ### 3️⃣ Automatic Sync Operation
@@ -273,6 +274,17 @@ Error: Insufficient permissions
   - ✅ Approve required permissions when executing script
   - ✅ Click "Review permissions" on "Authorization required" screen
 
+#### 7. **Calendar Usage Limits Exceeded**
+```
+Error: API call to calendar.events.insert failed with error: Calendar usage limits exceeded.
+```
+
+**Causes and Solutions:**  
+- ❌ Events outside the sync range were repeatedly created, exceeding Google Calendar API quotas
+  - ✅ Run `cleanupDuplicateEvents(true)` as a dry run to check the scale of duplicates
+  - ✅ Run `cleanupDuplicateEvents(false)` to delete duplicate events
+  - ✅ Update to the latest version to apply the date range filter fix
+
 ### 🔍 Debugging Methods
 
 #### Checking Logs
@@ -305,6 +317,15 @@ function checkConfiguration() {
   };
   Logger.log(config);
 }
+```
+
+#### Cleaning Up Duplicate Events
+```javascript
+// Check for duplicate events (dry run)
+cleanupDuplicateEvents(true);
+
+// Delete duplicate events (execute)
+cleanupDuplicateEvents(false);
 ```
 
 ### ⚠️ Important Notes

--- a/README_JP.md
+++ b/README_JP.md
@@ -279,8 +279,7 @@ Googleカレンダーから5件のイベントを取得
 
 **原因と解決方法:**  
 - ❌ 同期範囲外のイベントが繰り返し作成され、Google Calendar APIのクォータを超過
-  - ✅ `cleanupDuplicateEvents(true)` をドライランで実行し、重複の規模を確認
-  - ✅ `cleanupDuplicateEvents(false)` で重複イベントを削除
+  - ✅ `cleanupDuplicateEvents()` を実行して重複イベントを削除（完了まで繰り返し実行）
   - ✅ 最新バージョンに更新して日付範囲フィルターの修正を適用
 
 ### 🔍 デバッグ方法
@@ -319,11 +318,11 @@ function checkConfiguration() {
 
 #### 重複イベントのクリーンアップ
 ```javascript
-// 重複イベントの確認（ドライラン）
-cleanupDuplicateEvents(true);
+// 重複イベントの検出・削除（再開可能、完了まで繰り返し実行）
+cleanupDuplicateEvents();
 
-// 重複イベントの削除（実行）
-cleanupDuplicateEvents(false);
+// 進捗をリセットして最初からやり直す場合
+resetCleanupProgress();
 ```
 
 ### ⚠️ 注意事項

--- a/README_JP.md
+++ b/README_JP.md
@@ -141,6 +141,7 @@ initialize();
 #### 同期対象の条件
 - ✅ `Tags`に「Schedule」タグが含まれている
 - ✅ `Action Day`が設定されている
+- ✅ `Action Day`が同期範囲内（過去30日〜未来90日）である
 - ❌ 上記を満たさないアイテムは同期対象外
 
 ### 3️⃣ 自動同期の動作
@@ -271,6 +272,17 @@ Googleカレンダーから5件のイベントを取得
   - ✅ スクリプト実行時に必要な権限を承認
   - ✅ 「承認が必要です」の画面で「権限を確認」をクリック
 
+#### 7. **Calendar usage limits exceededエラー**
+```
+エラー: API call to calendar.events.insert failed with error: Calendar usage limits exceeded.
+```
+
+**原因と解決方法:**  
+- ❌ 同期範囲外のイベントが繰り返し作成され、Google Calendar APIのクォータを超過
+  - ✅ `cleanupDuplicateEvents(true)` をドライランで実行し、重複の規模を確認
+  - ✅ `cleanupDuplicateEvents(false)` で重複イベントを削除
+  - ✅ 最新バージョンに更新して日付範囲フィルターの修正を適用
+
 ### 🔍 デバッグ方法
 
 #### ログの確認
@@ -303,6 +315,15 @@ function checkConfiguration() {
   };
   Logger.log(config);
 }
+```
+
+#### 重複イベントのクリーンアップ
+```javascript
+// 重複イベントの確認（ドライラン）
+cleanupDuplicateEvents(true);
+
+// 重複イベントの削除（実行）
+cleanupDuplicateEvents(false);
 ```
 
 ### ⚠️ 注意事項

--- a/main.js
+++ b/main.js
@@ -57,18 +57,31 @@ function syncNotionWithGoogleCalendar() {
   }  
 }  
 
+/**
+ * 同期対象の日付範囲を返す（Notion・Googleカレンダー共通）
+ * @return {Object} { start: Date, end: Date }
+ */
+function getSyncDateRange() {
+  const now = new Date();
+  return {
+    start: new Date(now.getTime() - (30 * 24 * 60 * 60 * 1000)),
+    end: new Date(now.getTime() + (90 * 24 * 60 * 60 * 1000))
+  };
+}
+
 /**  
  * Notionから同期対象のスケジュールアイテムを取得
  */  
 function getNotionScheduleItems() {  
   try {  
-    // デバッグログ追加
     Logger.log(`SCHEDULE_TAG_ID: ${CONFIG.SCHEDULE_TAG_ID}`);
     Logger.log(`DATABASE_ID: ${CONFIG.NOTION_DATABASE_ID}`);
     
     const url = `https://api.notion.com/v1/databases/${CONFIG.NOTION_DATABASE_ID}/query`;  
+    const dateRange = getSyncDateRange();
+    const startDateStr = dateRange.start.toISOString().split('T')[0];
+    const endDateStr = dateRange.end.toISOString().split('T')[0];
     
-    // まずrelationタイプで試行
     const payload = {  
       filter: {  
         and: [  
@@ -81,9 +94,15 @@ function getNotionScheduleItems() {
           {  
             property: 'Action Day',  
             date: {  
-              is_not_empty: true  
+              on_or_after: startDateStr
             }  
-          }  
+          },
+          {  
+            property: 'Action Day',  
+            date: {  
+              on_or_before: endDateStr
+            }  
+          }
         ]  
       },  
       sorts: [  
@@ -161,13 +180,11 @@ function getPropertyValue(properties, propertyName) {
  */  
 function getGoogleCalendarEvents() {  
   try {  
-    const now = new Date();  
-    const oneMonthAgo = new Date(now.getTime() - (30 * 24 * 60 * 60 * 1000));  
-    const threeMonthLater = new Date(now.getTime() + (90 * 24 * 60 * 60 * 1000));  
+    const dateRange = getSyncDateRange();
     
     const events = Calendar.Events.list(CONFIG.CALENDAR_ID, {  
-      timeMin: oneMonthAgo.toISOString(),  
-      timeMax: threeMonthLater.toISOString(),  
+      timeMin: dateRange.start.toISOString(),  
+      timeMax: dateRange.end.toISOString(),  
       singleEvents: true,  
       orderBy: 'startTime',  
       maxResults: 1000  
@@ -289,7 +306,16 @@ function performSync(notionItems, calendarEvents) {
           result.updated++;  
         }  
       } else {  
-        // 新規作成  
+        // Notion側にEvent IDがあれば、カレンダーに存在するか確認（フェイルセーフ）
+        if (notionItem.eventId) {
+          try {
+            Calendar.Events.get(CONFIG.CALENDAR_ID, notionItem.eventId);
+            Logger.log(`既存イベント検出（範囲外）、スキップ: ${notionItem.title}`);
+            return;
+          } catch (e) {
+            // 404等 = イベント削除済み → 新規作成へ進む
+          }
+        }
         const eventId = createGoogleCalendarEvent(notionItem);  
         if (eventId) {  
           updateNotionEventId(notionItem.id, eventId);  
@@ -359,11 +385,7 @@ function needsUpdate(notionItem, calendarEvent) {
     }
   }
   
-  // 最終更新時刻の比較  
-  const notionUpdated = new Date(notionItem.lastEditedTime);  
-  const calendarUpdated = new Date(calendarEvent.updated);  
-  
-  return notionUpdated > calendarUpdated;  
+  return false;  
 }  
 
 /**  

--- a/test.js
+++ b/test.js
@@ -513,13 +513,14 @@ function cleanupDuplicateEvents() {
       Logger.log(`チャンク: ${chunkStart.toISOString().split('T')[0]} 〜 ${chunkEnd.toISOString().split('T')[0]}`);
 
       // q パラメータでサーバー側フィルタ（[Notion-Sync]イベントのみ取得）
+      const FETCH_LIMIT = 3500;
       const chunkEvents = [];
       let pageToken = null;
       let pageCount = 0;
-      let timedOut = false;
+      let fetchLimitReached = false;
       do {
-        if (Date.now() - startTime > TIME_LIMIT_MS) {
-          timedOut = true;
+        if (chunkEvents.length >= FETCH_LIMIT) {
+          fetchLimitReached = true;
           break;
         }
         pageCount++;
@@ -539,15 +540,15 @@ function cleanupDuplicateEvents() {
         Logger.log(`  ページ${pageCount}: ${fetched}件取得 / 累計: ${chunkEvents.length}件${pageToken ? ' (次ページあり)' : ''}`);
       } while (pageToken);
 
-      if (timedOut) {
-        Logger.log(`⏱ ページ取得中に時間上限に到達。取得済みイベントで重複処理を実行してから中断します。`);
+      if (fetchLimitReached) {
+        Logger.log(`  取得上限(${FETCH_LIMIT}件)に到達。取得済みイベントで重複処理を実行してから中断します。`);
       }
 
       // [Notion-Sync]の正確なフィルタ（qは部分一致のため）
       const syncEvents = chunkEvents.filter(e =>
         e.description && e.description.includes('[Notion-Sync]')
       );
-      Logger.log(`  取得: ${syncEvents.length}件${timedOut ? ' (部分取得)' : ''}`);
+      Logger.log(`  取得: ${syncEvents.length}件${fetchLimitReached ? ' (部分取得)' : ''}`);
 
       // Notion IDでグルーピング
       const groups = new Map();
@@ -588,8 +589,8 @@ function cleanupDuplicateEvents() {
         }
       });
 
-      // タイムアウト時は同じチャンクから再開（削除済み分が減るので次回は先に進める）
-      if (timedOut) {
+      // 取得上限到達時は同じチャンクから再開（削除済み分が減るので次回は先に進める）
+      if (fetchLimitReached) {
         props.setProperty(PROGRESS_KEY, JSON.stringify({
           nextChunkStart: chunkStart.toISOString(),
           totalDuplicates, totalDeleted

--- a/test.js
+++ b/test.js
@@ -460,14 +460,15 @@ function testImprovedSync() {
 
 /**
  * 重複する[Notion-Sync]イベントをクリーンアップ（再開可能）
- * 2週間ずつ処理し、進捗をScriptPropertiesに保存。タイムアウト時は再実行で続きから処理する。
+ * Googleカレンダーから同一Notion IDの重複イベントを検出し、最新の1件を残して削除する。
+ * 1週間ずつ処理し、進捗をScriptPropertiesに保存。タイムアウト時は再実行で続きから処理する。
  * @param {boolean} dryRun - trueの場合はログ出力のみ（実削除しない）
  */
 function cleanupDuplicateEvents(dryRun) {
   if (dryRun === undefined) dryRun = false;
 
-  const CHUNK_DAYS = 14;
-  const TIME_LIMIT_MS = 5 * 60 * 1000; // 5分で安全に停止（GAS上限6分）
+  const CHUNK_DAYS = 7;
+  const TIME_LIMIT_MS = 3 * 60 * 1000; // 3分で安全に停止（GAS上限6分）
   const startTime = Date.now();
   const props = PropertiesService.getScriptProperties();
   const PROGRESS_KEY = 'CLEANUP_PROGRESS';
@@ -518,7 +519,12 @@ function cleanupDuplicateEvents(dryRun) {
       const chunkEvents = [];
       let pageToken = null;
       let pageCount = 0;
+      let timedOut = false;
       do {
+        if (Date.now() - startTime > TIME_LIMIT_MS) {
+          timedOut = true;
+          break;
+        }
         pageCount++;
         const params = {
           timeMin: chunkStart.toISOString(),
@@ -536,11 +542,15 @@ function cleanupDuplicateEvents(dryRun) {
         Logger.log(`  ページ${pageCount}: ${fetched}件取得 / 累計: ${chunkEvents.length}件${pageToken ? ' (次ページあり)' : ''}`);
       } while (pageToken);
 
+      if (timedOut) {
+        Logger.log(`⏱ ページ取得中に時間上限に到達。取得済みイベントで重複処理を実行してから中断します。`);
+      }
+
       // [Notion-Sync]の正確なフィルタ（qは部分一致のため）
       const syncEvents = chunkEvents.filter(e =>
         e.description && e.description.includes('[Notion-Sync]')
       );
-      Logger.log(`  取得: ${syncEvents.length}件`);
+      Logger.log(`  取得: ${syncEvents.length}件${timedOut ? ' (部分取得)' : ''}`);
 
       // Notion IDでグルーピング
       const groups = new Map();
@@ -552,7 +562,7 @@ function cleanupDuplicateEvents(dryRun) {
         groups.get(nid).push(event);
       });
 
-      // 重複を処理
+      // 重複を処理（タイムアウト時も取得済み分は処理する）
       groups.forEach((eventList, notionId) => {
         if (eventList.length <= 1) return;
         eventList.sort((a, b) => new Date(b.updated) - new Date(a.updated));
@@ -565,12 +575,24 @@ function cleanupDuplicateEvents(dryRun) {
             try {
               Calendar.Events.remove(CONFIG.CALENDAR_ID, dup.id);
               totalDeleted++;
+              Utilities.sleep(200);
             } catch (e) {
               Logger.log(`    削除失敗 (${dup.id}): ${e.message}`);
+              Utilities.sleep(1000);
             }
           });
         }
       });
+
+      // タイムアウト時は同じチャンクから再開（削除済み分が減るので次回は先に進める）
+      if (timedOut) {
+        props.setProperty(PROGRESS_KEY, JSON.stringify({
+          nextChunkStart: chunkStart.toISOString(),
+          totalDuplicates, totalDeleted
+        }));
+        Logger.log(`--- 中間結果 --- 重複: ${totalDuplicates}件, 削除: ${totalDeleted}件`);
+        return { totalDuplicates, totalDeleted, completed: false };
+      }
 
       chunkStart = chunkEnd;
     }

--- a/test.js
+++ b/test.js
@@ -464,7 +464,7 @@ function testImprovedSync() {
  * @param {boolean} dryRun - trueの場合はログ出力のみ（実削除しない）
  */
 function cleanupDuplicateEvents(dryRun) {
-  if (dryRun === undefined) dryRun = true;
+  if (dryRun === undefined) dryRun = false;
 
   const CHUNK_DAYS = 14;
   const TIME_LIMIT_MS = 5 * 60 * 1000; // 5分で安全に停止（GAS上限6分）
@@ -492,8 +492,9 @@ function cleanupDuplicateEvents(dryRun) {
     Logger.log(`対象範囲: ${rangeStart.toISOString().split('T')[0]} 〜 ${rangeEnd.toISOString().split('T')[0]}`);
   }
 
+  let chunkStart = new Date(resumeFrom);
+
   try {
-    let chunkStart = new Date(resumeFrom);
     let completed = false;
 
     while (chunkStart < rangeEnd) {
@@ -516,7 +517,9 @@ function cleanupDuplicateEvents(dryRun) {
       // q パラメータでサーバー側フィルタ（[Notion-Sync]イベントのみ取得）
       const chunkEvents = [];
       let pageToken = null;
+      let pageCount = 0;
       do {
+        pageCount++;
         const params = {
           timeMin: chunkStart.toISOString(),
           timeMax: chunkEnd.toISOString(),
@@ -527,9 +530,10 @@ function cleanupDuplicateEvents(dryRun) {
         };
         if (pageToken) params.pageToken = pageToken;
         const response = Calendar.Events.list(CONFIG.CALENDAR_ID, params);
+        const fetched = response.items ? response.items.length : 0;
         if (response.items) chunkEvents.push(...response.items);
         pageToken = response.nextPageToken || null;
-        Logger.log(`    ページ${pageCount}: ${fetchedCount}件取得 / 累計: ${allItems.length}件${pageToken ? ' (次ページあり)' : ''}`);
+        Logger.log(`  ページ${pageCount}: ${fetched}件取得 / 累計: ${chunkEvents.length}件${pageToken ? ' (次ページあり)' : ''}`);
       } while (pageToken);
 
       // [Notion-Sync]の正確なフィルタ（qは部分一致のため）

--- a/test.js
+++ b/test.js
@@ -462,11 +462,8 @@ function testImprovedSync() {
  * 重複する[Notion-Sync]イベントをクリーンアップ（再開可能）
  * Googleカレンダーから同一Notion IDの重複イベントを検出し、最新の1件を残して削除する。
  * 1週間ずつ処理し、進捗をScriptPropertiesに保存。タイムアウト時は再実行で続きから処理する。
- * @param {boolean} dryRun - trueの場合はログ出力のみ（実削除しない）
  */
-function cleanupDuplicateEvents(dryRun) {
-  if (dryRun === undefined) dryRun = false;
-
+function cleanupDuplicateEvents() {
   const CHUNK_DAYS = 7;
   const TIME_LIMIT_MS = 3 * 60 * 1000; // 3分で安全に停止（GAS上限6分）
   const startTime = Date.now();
@@ -486,10 +483,10 @@ function cleanupDuplicateEvents(dryRun) {
   const isResumed = saved !== null;
 
   if (isResumed) {
-    Logger.log(`=== クリーンアップ再開 ${dryRun ? '(ドライラン)' : '(実行)'} ===`);
+    Logger.log(`=== クリーンアップ再開 ===`);
     Logger.log(`前回の進捗: 重複${totalDuplicates}件検出, ${totalDeleted}件削除済, ${resumeFrom.toISOString().split('T')[0]}から再開`);
   } else {
-    Logger.log(`=== 重複イベントクリーンアップ開始 ${dryRun ? '(ドライラン)' : '(実行)'} ===`);
+    Logger.log(`=== 重複イベントクリーンアップ開始 ===`);
     Logger.log(`対象範囲: ${rangeStart.toISOString().split('T')[0]} 〜 ${rangeEnd.toISOString().split('T')[0]}`);
   }
 
@@ -570,17 +567,24 @@ function cleanupDuplicateEvents(dryRun) {
         totalDuplicates += duplicates.length;
         Logger.log(`  ${eventList[0].summary}: ${eventList.length}件 (削除対象: ${duplicates.length})`);
 
-        if (!dryRun) {
-          duplicates.forEach(dup => {
-            try {
-              Calendar.Events.remove(CONFIG.CALENDAR_ID, dup.id);
-              totalDeleted++;
-              Utilities.sleep(200);
-            } catch (e) {
-              Logger.log(`    削除失敗 (${dup.id}): ${e.message}`);
-              Utilities.sleep(1000);
-            }
-          });
+        for (let i = 0; i < duplicates.length; i++) {
+          if (Date.now() - startTime > TIME_LIMIT_MS) {
+            Logger.log(`⏱ 削除処理中に時間上限に到達。進捗を保存して中断します。`);
+            props.setProperty(PROGRESS_KEY, JSON.stringify({
+              nextChunkStart: chunkStart.toISOString(),
+              totalDuplicates, totalDeleted
+            }));
+            Logger.log(`--- 中間結果 --- 重複: ${totalDuplicates}件, 削除: ${totalDeleted}件`);
+            return { totalDuplicates, totalDeleted, completed: false };
+          }
+          try {
+            Calendar.Events.remove(CONFIG.CALENDAR_ID, duplicates[i].id);
+            totalDeleted++;
+            Utilities.sleep(200);
+          } catch (e) {
+            Logger.log(`    削除失敗 (${duplicates[i].id}): ${e.message}`);
+            Utilities.sleep(1000);
+          }
         }
       });
 
@@ -602,11 +606,7 @@ function cleanupDuplicateEvents(dryRun) {
     props.deleteProperty(PROGRESS_KEY);
     Logger.log(`=== 完了 ===`);
     Logger.log(`重複イベント数: ${totalDuplicates}`);
-    if (!dryRun) {
-      Logger.log(`削除完了: ${totalDeleted}件`);
-    } else {
-      Logger.log(`※ ドライランのため削除は行われていません。実行するには cleanupDuplicateEvents(false) を呼び出してください`);
-    }
+    Logger.log(`削除完了: ${totalDeleted}件`);
     return { totalDuplicates, totalDeleted, completed: true };
 
   } catch (error) {

--- a/test.js
+++ b/test.js
@@ -456,4 +456,112 @@ function testImprovedSync() {
     Logger.log(`❌ 改善された同期機能テストエラー: ${error.message}`);  
     return false;  
   }  
+}
+
+/**
+ * 重複する[Notion-Sync]イベントをクリーンアップ
+ * 同一Notion IDを持つイベントが複数ある場合、最新の1件のみを残して削除する
+ * @param {boolean} dryRun - trueの場合はログ出力のみ（実削除しない）
+ */
+function cleanupDuplicateEvents(dryRun) {
+  if (dryRun === undefined) dryRun = true;
+  Logger.log(`=== 重複イベントクリーンアップ ${dryRun ? '(ドライラン)' : '(実行)'} ===`);
+
+  try {
+    const now = new Date();
+    const rangeStart = new Date(now.getTime() - (180 * 24 * 60 * 60 * 1000));
+    const rangeEnd = new Date(now.getTime() + (180 * 24 * 60 * 60 * 1000));
+
+    // 1ヶ月ごとのチャンクに分割して取得（Backend Error回避）
+    const allItems = [];
+    let chunkStart = new Date(rangeStart);
+    while (chunkStart < rangeEnd) {
+      const chunkEnd = new Date(Math.min(
+        chunkStart.getTime() + (30 * 24 * 60 * 60 * 1000),
+        rangeEnd.getTime()
+      ));
+      Logger.log(`チャンク取得中: ${chunkStart.toISOString().split('T')[0]} 〜 ${chunkEnd.toISOString().split('T')[0]}`);
+
+      let pageToken = null;
+      let pageCount = 0;
+      do {
+        pageCount++;
+        const params = {
+          timeMin: chunkStart.toISOString(),
+          timeMax: chunkEnd.toISOString(),
+          singleEvents: true,
+          orderBy: 'startTime',
+          maxResults: 250
+        };
+        if (pageToken) params.pageToken = pageToken;
+
+        const response = Calendar.Events.list(CONFIG.CALENDAR_ID, params);
+        const fetchedCount = response.items ? response.items.length : 0;
+        if (response.items) allItems.push(...response.items);
+        pageToken = response.nextPageToken || null;
+        Logger.log(`    ページ${pageCount}: ${fetchedCount}件取得 / 累計: ${allItems.length}件${pageToken ? ' (次ページあり)' : ''}`);
+      } while (pageToken);
+      Logger.log(`  → チャンク取得完了: ${chunkStart.toISOString().split('T')[0]} 〜 ${chunkEnd.toISOString().split('T')[0]} / 累計イベント数: ${allItems.length}件`);
+
+      chunkStart = chunkEnd;
+    }
+
+    const syncEvents = allItems.filter(event =>
+      event.description && event.description.includes('[Notion-Sync]')
+    );
+    Logger.log(`取得イベント総数: ${allItems.length}件`);
+    Logger.log(`[Notion-Sync] イベント数: ${syncEvents.length}件`);
+
+    const groupByNotionId = new Map();
+    syncEvents.forEach(event => {
+      const match = event.description.match(/\[Notion-Sync\]\s*Notion ID:\s*([a-f0-9-]+)/);
+      const notionId = match ? match[1] : null;
+      if (!notionId) return;
+
+      if (!groupByNotionId.has(notionId)) {
+        groupByNotionId.set(notionId, []);
+      }
+      groupByNotionId.get(notionId).push(event);
+    });
+
+    let totalDuplicates = 0;
+    let totalDeleted = 0;
+
+    groupByNotionId.forEach((eventList, notionId) => {
+      if (eventList.length <= 1) return;
+
+      eventList.sort((a, b) => new Date(b.updated) - new Date(a.updated));
+      const keep = eventList[0];
+      const duplicates = eventList.slice(1);
+      totalDuplicates += duplicates.length;
+
+      Logger.log(`Notion ID: ${notionId} → ${eventList.length}件 (保持: ${keep.summary}, 削除対象: ${duplicates.length}件)`);
+
+      if (!dryRun) {
+        duplicates.forEach(dup => {
+          try {
+            Calendar.Events.remove(CONFIG.CALENDAR_ID, dup.id);
+            totalDeleted++;
+          } catch (e) {
+            Logger.log(`  削除失敗 (${dup.id}): ${e.message}`);
+          }
+        });
+      }
+    });
+
+    Logger.log(`--- 結果 ---`);
+    Logger.log(`重複グループ数: ${Array.from(groupByNotionId.values()).filter(v => v.length > 1).length}`);
+    Logger.log(`重複イベント数: ${totalDuplicates}`);
+    if (!dryRun) {
+      Logger.log(`削除完了: ${totalDeleted}件`);
+    } else {
+      Logger.log(`※ ドライランのため削除は行われていません。実行するには cleanupDuplicateEvents(false) を呼び出してください`);
+    }
+
+    return { totalDuplicates, totalDeleted };
+
+  } catch (error) {
+    Logger.log(`❌ クリーンアップエラー: ${error.message}`);
+    throw error;
+  }
 }  

--- a/test.js
+++ b/test.js
@@ -459,109 +459,145 @@ function testImprovedSync() {
 }
 
 /**
- * 重複する[Notion-Sync]イベントをクリーンアップ
- * 同一Notion IDを持つイベントが複数ある場合、最新の1件のみを残して削除する
+ * 重複する[Notion-Sync]イベントをクリーンアップ（再開可能）
+ * 2週間ずつ処理し、進捗をScriptPropertiesに保存。タイムアウト時は再実行で続きから処理する。
  * @param {boolean} dryRun - trueの場合はログ出力のみ（実削除しない）
  */
 function cleanupDuplicateEvents(dryRun) {
   if (dryRun === undefined) dryRun = true;
-  Logger.log(`=== 重複イベントクリーンアップ ${dryRun ? '(ドライラン)' : '(実行)'} ===`);
+
+  const CHUNK_DAYS = 14;
+  const TIME_LIMIT_MS = 5 * 60 * 1000; // 5分で安全に停止（GAS上限6分）
+  const startTime = Date.now();
+  const props = PropertiesService.getScriptProperties();
+  const PROGRESS_KEY = 'CLEANUP_PROGRESS';
+
+  const now = new Date();
+  const rangeStart = new Date(now.getTime() - (180 * 24 * 60 * 60 * 1000));
+  const rangeEnd = new Date(now.getTime() + (180 * 24 * 60 * 60 * 1000));
+
+  // 前回の進捗を復元
+  let saved = null;
+  try { saved = JSON.parse(props.getProperty(PROGRESS_KEY)); } catch (_) {}
+  const resumeFrom = saved ? new Date(saved.nextChunkStart) : rangeStart;
+  let totalDuplicates = saved ? saved.totalDuplicates : 0;
+  let totalDeleted = saved ? saved.totalDeleted : 0;
+  const isResumed = saved !== null;
+
+  if (isResumed) {
+    Logger.log(`=== クリーンアップ再開 ${dryRun ? '(ドライラン)' : '(実行)'} ===`);
+    Logger.log(`前回の進捗: 重複${totalDuplicates}件検出, ${totalDeleted}件削除済, ${resumeFrom.toISOString().split('T')[0]}から再開`);
+  } else {
+    Logger.log(`=== 重複イベントクリーンアップ開始 ${dryRun ? '(ドライラン)' : '(実行)'} ===`);
+    Logger.log(`対象範囲: ${rangeStart.toISOString().split('T')[0]} 〜 ${rangeEnd.toISOString().split('T')[0]}`);
+  }
 
   try {
-    const now = new Date();
-    const rangeStart = new Date(now.getTime() - (180 * 24 * 60 * 60 * 1000));
-    const rangeEnd = new Date(now.getTime() + (180 * 24 * 60 * 60 * 1000));
+    let chunkStart = new Date(resumeFrom);
+    let completed = false;
 
-    // 1ヶ月ごとのチャンクに分割して取得（Backend Error回避）
-    const allItems = [];
-    let chunkStart = new Date(rangeStart);
     while (chunkStart < rangeEnd) {
+      if (Date.now() - startTime > TIME_LIMIT_MS) {
+        Logger.log(`⏱ 実行時間上限に近づいたため中断します。再実行で続きから処理されます。`);
+        props.setProperty(PROGRESS_KEY, JSON.stringify({
+          nextChunkStart: chunkStart.toISOString(),
+          totalDuplicates, totalDeleted
+        }));
+        Logger.log(`--- 中間結果 --- 重複: ${totalDuplicates}件, 削除: ${totalDeleted}件`);
+        return { totalDuplicates, totalDeleted, completed: false };
+      }
+
       const chunkEnd = new Date(Math.min(
-        chunkStart.getTime() + (30 * 24 * 60 * 60 * 1000),
+        chunkStart.getTime() + (CHUNK_DAYS * 24 * 60 * 60 * 1000),
         rangeEnd.getTime()
       ));
-      Logger.log(`チャンク取得中: ${chunkStart.toISOString().split('T')[0]} 〜 ${chunkEnd.toISOString().split('T')[0]}`);
+      Logger.log(`チャンク: ${chunkStart.toISOString().split('T')[0]} 〜 ${chunkEnd.toISOString().split('T')[0]}`);
 
+      // q パラメータでサーバー側フィルタ（[Notion-Sync]イベントのみ取得）
+      const chunkEvents = [];
       let pageToken = null;
-      let pageCount = 0;
       do {
-        pageCount++;
         const params = {
           timeMin: chunkStart.toISOString(),
           timeMax: chunkEnd.toISOString(),
+          q: '[Notion-Sync]',
           singleEvents: true,
           orderBy: 'startTime',
           maxResults: 250
         };
         if (pageToken) params.pageToken = pageToken;
-
         const response = Calendar.Events.list(CONFIG.CALENDAR_ID, params);
-        const fetchedCount = response.items ? response.items.length : 0;
-        if (response.items) allItems.push(...response.items);
+        if (response.items) chunkEvents.push(...response.items);
         pageToken = response.nextPageToken || null;
         Logger.log(`    ページ${pageCount}: ${fetchedCount}件取得 / 累計: ${allItems.length}件${pageToken ? ' (次ページあり)' : ''}`);
       } while (pageToken);
-      Logger.log(`  → チャンク取得完了: ${chunkStart.toISOString().split('T')[0]} 〜 ${chunkEnd.toISOString().split('T')[0]} / 累計イベント数: ${allItems.length}件`);
+
+      // [Notion-Sync]の正確なフィルタ（qは部分一致のため）
+      const syncEvents = chunkEvents.filter(e =>
+        e.description && e.description.includes('[Notion-Sync]')
+      );
+      Logger.log(`  取得: ${syncEvents.length}件`);
+
+      // Notion IDでグルーピング
+      const groups = new Map();
+      syncEvents.forEach(event => {
+        const match = event.description.match(/\[Notion-Sync\]\s*Notion ID:\s*([a-f0-9-]+)/);
+        if (!match) return;
+        const nid = match[1];
+        if (!groups.has(nid)) groups.set(nid, []);
+        groups.get(nid).push(event);
+      });
+
+      // 重複を処理
+      groups.forEach((eventList, notionId) => {
+        if (eventList.length <= 1) return;
+        eventList.sort((a, b) => new Date(b.updated) - new Date(a.updated));
+        const duplicates = eventList.slice(1);
+        totalDuplicates += duplicates.length;
+        Logger.log(`  ${eventList[0].summary}: ${eventList.length}件 (削除対象: ${duplicates.length})`);
+
+        if (!dryRun) {
+          duplicates.forEach(dup => {
+            try {
+              Calendar.Events.remove(CONFIG.CALENDAR_ID, dup.id);
+              totalDeleted++;
+            } catch (e) {
+              Logger.log(`    削除失敗 (${dup.id}): ${e.message}`);
+            }
+          });
+        }
+      });
 
       chunkStart = chunkEnd;
     }
+    completed = true;
 
-    const syncEvents = allItems.filter(event =>
-      event.description && event.description.includes('[Notion-Sync]')
-    );
-    Logger.log(`取得イベント総数: ${allItems.length}件`);
-    Logger.log(`[Notion-Sync] イベント数: ${syncEvents.length}件`);
-
-    const groupByNotionId = new Map();
-    syncEvents.forEach(event => {
-      const match = event.description.match(/\[Notion-Sync\]\s*Notion ID:\s*([a-f0-9-]+)/);
-      const notionId = match ? match[1] : null;
-      if (!notionId) return;
-
-      if (!groupByNotionId.has(notionId)) {
-        groupByNotionId.set(notionId, []);
-      }
-      groupByNotionId.get(notionId).push(event);
-    });
-
-    let totalDuplicates = 0;
-    let totalDeleted = 0;
-
-    groupByNotionId.forEach((eventList, notionId) => {
-      if (eventList.length <= 1) return;
-
-      eventList.sort((a, b) => new Date(b.updated) - new Date(a.updated));
-      const keep = eventList[0];
-      const duplicates = eventList.slice(1);
-      totalDuplicates += duplicates.length;
-
-      Logger.log(`Notion ID: ${notionId} → ${eventList.length}件 (保持: ${keep.summary}, 削除対象: ${duplicates.length}件)`);
-
-      if (!dryRun) {
-        duplicates.forEach(dup => {
-          try {
-            Calendar.Events.remove(CONFIG.CALENDAR_ID, dup.id);
-            totalDeleted++;
-          } catch (e) {
-            Logger.log(`  削除失敗 (${dup.id}): ${e.message}`);
-          }
-        });
-      }
-    });
-
-    Logger.log(`--- 結果 ---`);
-    Logger.log(`重複グループ数: ${Array.from(groupByNotionId.values()).filter(v => v.length > 1).length}`);
+    // 完了 → 進捗をクリア
+    props.deleteProperty(PROGRESS_KEY);
+    Logger.log(`=== 完了 ===`);
     Logger.log(`重複イベント数: ${totalDuplicates}`);
     if (!dryRun) {
       Logger.log(`削除完了: ${totalDeleted}件`);
     } else {
       Logger.log(`※ ドライランのため削除は行われていません。実行するには cleanupDuplicateEvents(false) を呼び出してください`);
     }
-
-    return { totalDuplicates, totalDeleted };
+    return { totalDuplicates, totalDeleted, completed: true };
 
   } catch (error) {
-    Logger.log(`❌ クリーンアップエラー: ${error.message}`);
+    // エラー時も進捗を保存（次回再開可能）
+    props.setProperty(PROGRESS_KEY, JSON.stringify({
+      nextChunkStart: chunkStart.toISOString(),
+      totalDuplicates, totalDeleted
+    }));
+    Logger.log(`❌ エラー発生（進捗は保存済み、再実行で続行可能）: ${error.message}`);
     throw error;
   }
+}
+
+/**
+ * クリーンアップの進捗をリセット（最初からやり直す場合に使用）
+ */
+function resetCleanupProgress() {
+  PropertiesService.getScriptProperties().deleteProperty('CLEANUP_PROGRESS');
+  Logger.log('クリーンアップの進捗をリセットしました');
 }  

--- a/test.js
+++ b/test.js
@@ -513,7 +513,7 @@ function cleanupDuplicateEvents() {
       Logger.log(`チャンク: ${chunkStart.toISOString().split('T')[0]} 〜 ${chunkEnd.toISOString().split('T')[0]}`);
 
       // q パラメータでサーバー側フィルタ（[Notion-Sync]イベントのみ取得）
-      const FETCH_LIMIT = 3500;
+      const FETCH_LIMIT = 750;
       const chunkEvents = [];
       let pageToken = null;
       let pageCount = 0;

--- a/test.js
+++ b/test.js
@@ -465,7 +465,7 @@ function testImprovedSync() {
  */
 function cleanupDuplicateEvents() {
   const CHUNK_DAYS = 7;
-  const TIME_LIMIT_MS = 3 * 60 * 1000; // 3分で安全に停止（GAS上限6分）
+  const TIME_LIMIT_MS = 5 * 60 * 1000; // 5分で安全に停止（GAS上限6分）
   const startTime = Date.now();
   const props = PropertiesService.getScriptProperties();
   const PROGRESS_KEY = 'CLEANUP_PROGRESS';

--- a/test.js
+++ b/test.js
@@ -581,7 +581,7 @@ function cleanupDuplicateEvents() {
           try {
             Calendar.Events.remove(CONFIG.CALENDAR_ID, duplicates[i].id);
             totalDeleted++;
-            Utilities.sleep(200);
+            Utilities.sleep(100);
           } catch (e) {
             Logger.log(`    削除失敗 (${duplicates[i].id}): ${e.message}`);
             Utilities.sleep(1000);


### PR DESCRIPTION
# 概要
Notion側とGoogleカレンダー側の取得範囲の不一致による無限イベント作成ループによるGoogle Calender APIコールエラーを修正

## 対応

1. getNotionScheduleItems に日付範囲フィルターを追加 — Googleカレンダー側と同じ範囲（1ヶ月前〜3ヶ月後）に限定する
2. Event IDベースの重複チェックを追加 — 新規作成前に notionItem.eventId が既にセットされている場合、Calendar.Events.get で存在確認を行い、存在すればスキップ
3. needsUpdate のタイムスタンプ比較を削除または改善 — 内容（タイトル・日付）の比較のみで更新判断する
4. Googleカレンダー上の重複イベントのクリーンアップ — 1ヶ月分の重複イベントを削除するユーティリティ関数を作成